### PR TITLE
Fix links to commits by linking to GitHub

### DIFF
--- a/Web/App/index.html
+++ b/Web/App/index.html
@@ -91,7 +91,7 @@
           </header>
           <div class="content">
             <div>
-              <a href="https://roslyn.codeplex.com/SourceControl/changeset/{{branch.lastCommitHash}}" target="_blank">{{branch.lastCommitHash}}</a>
+				<a href="https://github.com/dotnet/roslyn/commit/{{branch.lastCommitHash}}" target="_blank">{{branch.lastCommitHash}}</a>
               at {{branch.lastCommitDate | date:'dd MMM yyyy'}}
               by <a href="https://www.codeplex.com/site/users/view/{{branch.lastCommitAuthor}}" target="_blank">{{branch.lastCommitAuthor}}</a>
             </div>


### PR DESCRIPTION
Recent commit hashes won't be on codeplex, but old commit hashes
should work on GitHub