### PR TITLE
Improve the default C#/VB code samples

### DIFF
--- a/source/Web/js/state/handlers/defaults.js
+++ b/source/Web/js/state/handlers/defaults.js
@@ -1,6 +1,6 @@
 const code = {
-    csharp: 'using System;\r\npublic class C {\r\n    public void M() {\r\n    }\r\n}',
-    vbnet:  'Imports System\r\nPublic Class C\r\n    Public Sub M()\r\n    End Sub\r\nEnd Class'
+    csharp: 'using System;\r\nusing System.Collections.Generic;\r\nusing System.Linq;\r\nusing System.Runtime.CompilerServices;\r\nusing System.Threading.Tasks;\r\n\r\npublic class Class1\r\n{\r\n    public void Method1()\r\n    {\r\n    }\r\n}',
+    vbnet:  'Imports System\r\nImports System.Collections.Generic\r\nImports System.Linq\r\nImports System.Runtime.CompilerServices\r\nImports System.Threading.Tasks\r\n\r\nPublic Class Class1\r\n    Public Sub Method1()\r\n    End Sub\r\nEnd Class'
 };
 
 export default {


### PR DESCRIPTION
Hi, thanks for the awesome site :grinning: I use it pretty frequently, since I'm too lazy to manually compile a project/open up ILSpy for a small snippet of code.

Whenever I use TryRoslyn, I find myself moving the braces to the next line to match the typical C# code style, and adding a couple of `using` directives (mostly to `System.Collections.Generic` or `System.Threading.Tasks`) to see how IEnumerable/Tasks are implemented. I got a bit tired of doing this (and I'm sure some others are too), so I decided to submit a PR here. Could you please take a look? :D
