### PR TITLE
Handle regular changes of referenced System.Reflection.Metadata version

### DIFF
--- a/#build/Build-All.ps1
+++ b/#build/Build-All.ps1
@@ -221,8 +221,7 @@ try {
                         Rewrite-Package-Version $_ $packagesMap
                     }
                     
-                    Write-Output "Updating site nuget packages..."
-                    Write-Output "$siteBuildRoot\TryRoslyn.sln"
+                    Write-Output "Restoring site packages..."
                     &"$PSScriptRoot\#tools\nuget" restore "$siteBuildRoot\TryRoslyn.sln"
 
                     Write-Output "Building Web.Api.csproj..."

--- a/#build/Build-All.ps1
+++ b/#build/Build-All.ps1
@@ -30,6 +30,29 @@ function Format-Xml($xml) {
     return $stringWriter.ToString()
 }
 
+function Get-Package-Version($path, $lib) {
+    $content = [IO.File]::ReadAllText((Resolve-Path $path))
+    $json = $content | ConvertFrom-Json
+    return $json.dependencies.$lib
+}
+
+function Rewrite-Package-Version($packagesPath, $map) {
+    $content = [IO.File]::ReadAllText((Resolve-Path $packagesPath))
+    $contentXml = [xml]$content
+    $map.GetEnumerator() | % {
+        $name = $_.Key
+        $version = $_.Value
+        Select-Xml $contentXml -XPath '//package' |
+            ? { $_.Node.id -match "^$([regex]::Escape($name))" } |
+            % { $_.Node.version = $version }
+    }
+    $rewritten = Format-Xml $contentXml
+    if ($rewritten -eq $content) {
+        return
+    }
+    Set-Content $packagesPath $rewritten
+}
+
 function Rewrite-ProjectReferences($projectPath, $map) {
     $xmlNamespaces = @{msbuild='http://schemas.microsoft.com/developer/msbuild/2003'}
 
@@ -174,15 +197,33 @@ try {
                 try {
                     $buildLogPath = "$siteBuildRoot\!build.log"
 
-                    Write-Output "Rewriting *.csproj files..."
-                    Get-ChildItem *.csproj -Recurse -ErrorAction SilentlyContinue | % {
-                        Rewrite-ProjectReferences $_ @{
+                    $map = @{
                             'Microsoft.CodeAnalysis'             = "$roslynBinaryRoot\Microsoft.CodeAnalysis.dll"
                             'Microsoft.CodeAnalysis.CSharp'      = "$roslynBinaryRoot\Microsoft.CodeAnalysis.CSharp.dll"
                             'Microsoft.CodeAnalysis.VisualBasic' = "$roslynBinaryRoot\Microsoft.CodeAnalysis.VisualBasic.dll"
                         }
+                    $packagesMap = @{}
+                    $metadataDependencyJsonPath = "$($roslynSourceRoot)\src\Dependencies\Metadata\project.json"
+                    if (Test-Path $metadataDependencyJsonPath) {
+                        $metadataVersion = Get-Package-Version $metadataDependencyJsonPath "System.Reflection.Metadata"
+                        Write-Output "System.Reflection.Metadata $($metadataVersion)"
+                        $map['System.Reflection.Metadata'] = "..\#packages\System.Reflection.Metadata.$($metadataVersion)\lib\portable-net45+win8\System.Reflection.Metadata.dll"
+                        $packagesMap['System.Reflection.Metadata'] = $metadataVersion
+                    }
+                    Write-Output "Rewriting *.csproj files..."
+                    Get-ChildItem *.csproj -Recurse -ErrorAction SilentlyContinue | % {
+                        Rewrite-ProjectReferences $_ $map
                         Write-Output "  $($_.Name)"
                     }
+                    
+                    Write-Output "Rewriting packages.congig files..."
+                    Get-ChildItem packages.config -Recurse -ErrorAction SilentlyContinue | % {
+                        Rewrite-Package-Version $_ $packagesMap
+                    }
+                    
+                    Write-Output "Updating site nuget packages..."
+                    Write-Output "$siteBuildRoot\TryRoslyn.sln"
+                    &"$PSScriptRoot\#tools\nuget" restore "$siteBuildRoot\TryRoslyn.sln"
 
                     Write-Output "Building Web.Api.csproj..."
                     &$MSBuild Web.Api\Web.Api.csproj > $buildLogPath `

--- a/source/NuGet.Config
+++ b/source/NuGet.Config
@@ -4,7 +4,7 @@
     <add key="repositoryPath" value="#packages" />
   </config>
   <packageSources>
-	  <clear />
+    <clear />
     <add key="myget.org dotnet-coreclr" value="https://dotnet.myget.org/F/dotnet-coreclr/api/v3/index.json" />
     <add key="myget.org dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="myget.org dotnet-corefxtestdata" value="https://dotnet.myget.org/F/dotnet-corefxtestdata/api/v3/index.json" />

--- a/source/NuGet.Config
+++ b/source/NuGet.Config
@@ -1,6 +1,17 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <config>
     <add key="repositoryPath" value="#packages" />
   </config>
+  <packageSources>
+	  <clear />
+    <add key="myget.org dotnet-coreclr" value="https://dotnet.myget.org/F/dotnet-coreclr/api/v3/index.json" />
+    <add key="myget.org dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="myget.org dotnet-corefxtestdata" value="https://dotnet.myget.org/F/dotnet-corefxtestdata/api/v3/index.json" />
+    <add key="myget.org dotnet-buildtools" value="https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
+    <add key="myget.org symreader" value="https://dotnet.myget.org/F/symreader/api/v3/index.json" />
+    <add key="myget.org symreader-portable" value="https://dotnet.myget.org/F/symreader-portable/api/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <disabledPackageSources />
 </configuration>


### PR DESCRIPTION
System.Reflection.Metadata version which Roslyn depends on changes every couple of days lately (https://github.com/dotnet/roslyn/commits/master/src/Dependencies/Metadata/project.json). This issue usually breaks TryRoslyn's compilation or dependency injection behavior (e.g. master branch is completely broken currently in the latest TryRoslyn version)

Fix should take care of it by patching sites' packages and references based on corresponding Roslyn branch.