### PR TITLE
Default C# source style matches decompiled style

### DIFF
--- a/source/WebApp/js/state/handlers/defaults.js
+++ b/source/WebApp/js/state/handlers/defaults.js
@@ -1,7 +1,7 @@
 import languages from '../../helpers/languages.js';
 
 const code = {
-    [languages.csharp]: 'using System;\r\npublic class C {\r\n    public void M() {\r\n    }\r\n}',
+    [languages.csharp]: 'using System;\r\n\r\npublic class C\r\n{\r\n    public void M()\r\n{\r\n    }\r\n}',
     [languages.vb]:  'Imports System\r\nPublic Class C\r\n    Public Sub M()\r\n    End Sub\r\nEnd Class'
 };
 


### PR DESCRIPTION
I understand that the project uses the braces-on-same-line style. This just makes the source code match the decompiled C# code style (braces-on-own-line).

Default VB source already matches the decompiled style.